### PR TITLE
Add SwiftUI example for App Store rankings

### DIFF
--- a/AppStoreRankingApp/Info.plist
+++ b/AppStoreRankingApp/Info.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>com.example.AppStoreRankingApp</string>
+    <key>CFBundleName</key>
+    <string>AppStoreRankingApp</string>
+    <key>UILaunchStoryboardName</key>
+    <string>LaunchScreen</string>
+    <key>UIRequiredDeviceCapabilities</key>
+    <array>
+        <string>armv7</string>
+    </array>
+</dict>
+</plist>

--- a/AppStoreRankingApp/README.md
+++ b/AppStoreRankingApp/README.md
@@ -1,0 +1,10 @@
+# AppStoreRankingApp
+
+This is a simple SwiftUI iOS app that fetches the top free apps from Apple's RSS feed and displays them in a list. Tapping an item opens the app's App Store page.
+
+## Usage
+1. Open `AppStoreRankingApp` folder in Xcode as a new project.
+2. Ensure your deployment target is iOS 14 or later.
+3. Build and run on a simulator or device.
+
+The network request uses `https://rss.applemarketingtools.com/api/v2/us/apps/top-free/10/apps.json` to retrieve the top free apps in the U.S. store.

--- a/AppStoreRankingApp/Sources/AppStoreRankingApp.swift
+++ b/AppStoreRankingApp/Sources/AppStoreRankingApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct AppStoreRankingApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/AppStoreRankingApp/Sources/ContentView.swift
+++ b/AppStoreRankingApp/Sources/ContentView.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+struct AppResult: Codable, Identifiable {
+    let id: String
+    let name: String
+    let artistName: String
+    let url: String
+}
+
+struct Feed: Codable {
+    let results: [AppResult]
+}
+
+struct AppResponse: Codable {
+    let feed: Feed
+}
+
+struct ContentView: View {
+    @State private var apps: [AppResult] = []
+
+    var body: some View {
+        NavigationView {
+            List(apps) { app in
+                VStack(alignment: .leading) {
+                    Text(app.name).font(.headline)
+                    Text(app.artistName).font(.subheadline)
+                }
+                .onTapGesture {
+                    if let url = URL(string: app.url) {
+                        UIApplication.shared.open(url)
+                    }
+                }
+            }
+            .navigationTitle("Top Apps")
+            .onAppear(perform: fetchData)
+        }
+    }
+
+    func fetchData() {
+        guard let url = URL(string: "https://rss.applemarketingtools.com/api/v2/us/apps/top-free/10/apps.json") else {
+            return
+        }
+        let task = URLSession.shared.dataTask(with: url) { data, _, _ in
+            if let data = data {
+                if let decoded = try? JSONDecoder().decode(AppResponse.self, from: data) {
+                    DispatchQueue.main.async {
+                        self.apps = decoded.feed.results
+                    }
+                }
+            }
+        }
+        task.resume()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}


### PR DESCRIPTION
## Summary
- add `AppStoreRankingApp` SwiftUI example project
  - fetches Apple's top free apps RSS feed
  - lists app names and creators with link to App Store

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c0fac9bb8832ba8bbe1dd2705e92f